### PR TITLE
Allow Accept as CORS request header

### DIFF
--- a/timeseries-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/timeseries-webapp/src/main/webapp/WEB-INF/web.xml
@@ -29,7 +29,7 @@
 		</init-param>
 		<init-param>
 			<param-name>cors.supportedHeaders</param-name>
-			<param-value>Content-Type, Content-Encoding</param-value>
+			<param-value>Content-Type, Content-Encoding, Accept</param-value>
         </init-param>
         <init-param>
             <param-name>cors.exposedHeaders</param-name>


### PR DESCRIPTION
Currently I can't set `Accept` as a request header (e.g. to request a `image/png`) as the CORS preflight request fails:
```sh
curl 'http://pilot.52north.org/rtp-sos-webapp/api/v1/timeseries/ts_26e4564dd4d31ff283404452f7fcb23f/getData?base64=true' \
  -X OPTIONS \
  -H 'Access-Control-Request-Method: POST' \
  -H 'Origin: http://localhost' \
  -H 'Accept-Language: de'  \
  -H 'Accept: */*' \
  -H 'Access-Control-Request-Headers: accept, content-type' -v
```
```
HTTP/1.1 403 Forbidden
Server: nginx/1.6.2
Date: Thu, 05 Nov 2015 11:12:28 GMT
Content-Type: text/plain;charset=ISO-8859-1
Content-Length: 85
Connection: keep-alive

Cross-Origin Resource Sharing (CORS) Filter: Unsupported HTTP request header: Accept
```