### PR TITLE
Remove metadata extension from default configuration

### DIFF
--- a/timeseries-spi-impl/sos-series-dao/src/main/resources/README
+++ b/timeseries-spi-impl/sos-series-dao/src/main/resources/README
@@ -48,6 +48,7 @@ If you use the SOS e-Reporting database concept, you should modify the HIBERNATE
 
 HIBERNATE_DIRECTORY=/hbm/sos/core;/hbm/sos/ereporting
 
+
  Adding extra metadata fields
 ----------------------------------
 
@@ -55,7 +56,7 @@ Adding extra metadata to each series can be done by creating an extra metadata t
 Apply `src/extension/metadata/create_metadata_table.sql` and add some metadata to it.
 Add `/hbm/sos/metadata` to the HIBERNATE_DIRECTORY:
 
-HIBERNATE_DIRECTORY=/hbm/sos/core;/hbm/sos/metadata
+HIBERNATE_DIRECTORY=/hbm/sos/core;/hbm/sos/series;/hbm/sos/metadata
 
 Now configure the metadata extension to the Web interface so the data can be accessed. 
 Open the `timeseries-api_v1_web.xml` add the bean 

--- a/timeseries-webapp/src/main/resources/datasource.properties
+++ b/timeseries-webapp/src/main/resources/datasource.properties
@@ -2,7 +2,7 @@
 org.n52.sos.ds.Datasource=org.n52.sos.ds.datasource.PostgresDatasource
 
 # (currently absolute) path to mapping files
-HIBERNATE_DIRECTORY=/hbm/sos/core;/hbm/sos/series;/hbm/sos/metadata
+HIBERNATE_DIRECTORY=/hbm/sos/core;/hbm/sos/series
 
 # hibernate/postgres configuration
 

--- a/timeseries-webapp/src/main/webapp/WEB-INF/spring/timeseries-api_v1_web.xml
+++ b/timeseries-webapp/src/main/webapp/WEB-INF/spring/timeseries-api_v1_web.xml
@@ -66,7 +66,7 @@
                 <bean class="org.n52.io.extension.v1.StatusIntervalsExtension" />
                 <!-- Using DatabaseMetadataExtension requires some preparation work. -->
                 <!-- Have a look at the README.md at TBD -->
-                <bean class="org.n52.io.extension.DatabaseMetadataExtension" />
+                <!-- <bean class="org.n52.io.extension.DatabaseMetadataExtension" /> -->
             </list>
         </property>
     </bean>


### PR DESCRIPTION
The metadata extension should not be contained in the default configuration of the REST-API because this extention requires additional database tables.